### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,7 @@
 class ProductsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
   before_action :current_user_product_user, except: [:index, :new, :create, :show]
+  before_action :set_product,only: [:edit, :show, :update]
   def index
     @product = Product.order('created_at DESC')
   end
@@ -19,17 +20,17 @@ class ProductsController < ApplicationController
   end
 
   def show
-    @product = Product.find(params[:id])
+   
   end
 
 
   def edit
   
-    @product = Product.find(params[:id])
+    
   end
 
   def update
-    @product = Product.find(params[:id])
+    
     if @product.update(products_params)
    redirect_to product_path
    else
@@ -58,5 +59,9 @@ class ProductsController < ApplicationController
       redirect_to action: :index
     end
   end
+
+  def set_product
+    @product = Product.find(params[:id])
+   end
 
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -21,16 +21,15 @@ class ProductsController < ApplicationController
     @product = Product.find(params[:id])
   end
 
-<
+
   def edit
-    #binding.pry
+  
     @product = Product.find(params[:id])
   end
 
   def update
     @product = Product.find(params[:id])
     if @product.update(products_params)
-      #binding.pry
    redirect_to product_path
    else
    render :edit

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,6 @@
 class ProductsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
+  before_action :current_user_product_user, except: [:index, :new, :create, :show]
   def index
     @product = Product.order('created_at DESC')
   end
@@ -48,6 +49,14 @@ class ProductsController < ApplicationController
   def products_params
     params.require(:product).permit(:name, :details, :category_id, :condition_id, :ship_method_id, :prefecture_id, :day_ship_id,
                                     :price, :image).merge(user_id: current_user.id)
+  end
+
+  
+  def current_user_product_user
+    @product = Product.find(params[:id])
+    unless current_user.id == @product.user.id
+      redirect_to action: :index
+    end
   end
 
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -21,9 +21,28 @@ class ProductsController < ApplicationController
     @product = Product.find(params[:id])
   end
 
-  #def edit
+<
+  def edit
+    #binding.pry
+    @product = Product.find(params[:id])
+  end
+
+  def update
+    @product = Product.find(params[:id])
+    if @product.update(products_params)
+      #binding.pry
+   redirect_to product_path
+   else
+   render :edit
+   end
+  end
+
+  #def destroy
     #@product = Product.find(params[:id])
-  #end
+    # @product.destroy
+     #redirect_to root_path
+   #end
+
 
   private
 

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -7,13 +7,13 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model:@product,local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+   
+    <%= render 'shared/error_messages', model: f.object %>
+    
 
-    <%# 商品画像 %>
+    
     <div class="img-upload">
       <div class="weight-bold-text">
         商品画像
@@ -23,28 +23,25 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
-    <%# /商品画像 %>
-    <%# 商品名と商品説明 %>
+    
     <div class="new-items">
       <div class="weight-bold-text">
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :details, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
-    <%# /商品名と商品説明 %>
-
-    <%# 商品の詳細 %>
+   
     <div class="items-detail">
       <div class="weight-bold-text">商品の詳細</div>
       <div class="form">
@@ -52,15 +49,15 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
-    <%# /商品の詳細 %>
+    
 
     <%# 配送について %>
     <div class="items-detail">
@@ -73,17 +70,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:ship_method_id, ShipMethod.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:day_ship_id, DayShip.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +98,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,7 +138,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', root_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -132,7 +132,10 @@
 
         <% @product.each do |product| %>
       <li class='list'>
+
         <%= link_to  product_path(product.id) do %>
+
+ 
         <div class='item-img-content'>
           <%= image_tag product.image, class: "item-img" %>
 

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -16,26 +16,26 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-       <%=@product.price%>
+<
+        <%= @product.price %>
       </span>
       <span class="item-postage">
-        <%= @product.ship_method.name %>
+        <%= @product.ship_method.name%>
+
       </span>
     </div>
 
     
-
     <%if user_signed_in? %>
     <%if current_user.id == @product.user_id %>
-    <%= link_to "商品の編集","#", method: :get, class: "item-red-btn" %>
+    <%= link_to "商品の編集", edit_product_path(@product.id), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-    <%else%>
+    <%= link_to "削除",  product_path(@product.id), method: :delete, class:"item-destroy" %>
+    <%end%>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%end%>
-    <%end%>
 
-   
+    
 
     <div class="item-explain-box">
       <span><%= @product.details %></span>
@@ -44,7 +44,9 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
+
           <td class="detail-value"><%=@product.user.nickname  %></td>
+
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to:"products#index"
-  resources :products, only: [:index,:new,:create,:show,]
+
+  resources :products, only: [:index,:new,:create,:edit,:update,:show,]
 
 end


### PR DESCRIPTION
# what
コントローラーにアップデートとeditアクションを記述した
# why
編集機能実装のため

ログイン状態の出品者は、商品情報編集ページに遷移できる動画
　https://gyazo.com/c1acfd0d5771c1a84705a29901105ab1

正しく情報を記入すると、商品の情報を編集できる動画
　https://gyazo.com/85c46df0f6d314ed961ff32e627fcec0

入力に問題のある状態では商品の情報は編集できず、エラーメッセージが出力される動画
　https://gyazo.com/202646011f75e550892d69cc0a002bf9
　
何も編集せずに更新をしても画像無しの商品にならない動画
　https://gyazo.com/beaae1688903000586a643fec012a796
　
ログイン状態のユーザーであっても、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画
ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移する動画
　https://gyazo.com/44e420760f1c98aa2d660a721fe180fe
　
ログイン状態の出品者であっても、URLを直接入力して自身の売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）
　実装していないためなし

商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（画像に関しては、表示されない状態で良い）
　https://gyazo.com/c1acfd0d5771c1a84705a29901105ab1
　